### PR TITLE
Tables creation correction

### DIFF
--- a/alo-easymail.php
+++ b/alo-easymail.php
@@ -219,17 +219,15 @@ function alo_em_install_db_tables() {
     //-------------------------------------------------------------------------
 	
     if ( alo_em_db_tables_need_update()  ) {
-	    
-        $charset_collate = '';
 
-        if ( ! empty( $wpdb->charset ) ) {
-            $charset_collate = "DEFAULT CHARACTER SET {$wpdb->charset}";
-        }
+	    $charset_collate = '';
+	    if ( ! empty( $wpdb->charset ) ) {
+		    $charset_collate = "DEFAULT CHARACTER SET {$wpdb->charset}";
+	    }
+	    if ( ! empty( $wpdb->collate ) ) {
+		    $charset_collate .= " COLLATE {$wpdb->collate}";
+	    }
 
-        if ( ! empty( $wpdb->collate ) ) {
-            $charset_collate .= " COLLATE {$wpdb->collate}";
-        }
-		
 	    // Create the table structure
 	    $sql = "CREATE TABLE {$wpdb->prefix}easymail_subscribers ( 
 				    ID int(11) unsigned NOT NULL auto_increment , 


### PR DESCRIPTION
Tables creation can fail under certain circumstances because of the way COLLATE was used. I just reformat a little bit this code so it follows the guidelines given in http://codex.wordpress.org/Creating_Tables_with_Plugins  
