### PR TITLE
Exclude page & Polylang deprecation fixes

### DIFF
--- a/functions/alo-easymail-frontend.php
+++ b/functions/alo-easymail-frontend.php
@@ -27,11 +27,18 @@ add_action('wp_enqueue_scripts', 'alo_em_load_scripts');
  * Exclude the easymail page from pages' list
  */
 function alo_em_exclude_page( $pages ) {
-	if ( !is_admin() ) {
-		for ( $i=0; $i<count($pages); $i++ ) {
-			$page = & $pages[$i];
-			if ($page->ID == get_option('alo_em_subsc_page')) unset ($pages[$i]);
+	if ( !is_admin() )
+	{
+		$indexes = array();
+		foreach ($pages as $index => $page) {
+			if ($page->ID == get_option('alo_em_subsc_page'))
+				$indexes[] = $index;
 		}
+		foreach ($indexes as $index) {
+			if (isset($pages[$index]))
+				unset($pages[$index]);
+		}
+		unset($indexes);
 	}
 	return $pages;
 }

--- a/functions/alo-easymail-frontend.php
+++ b/functions/alo-easymail-frontend.php
@@ -30,8 +30,9 @@ function alo_em_exclude_page( $pages ) {
 	if ( !is_admin() )
 	{
 		$indexes = array();
+		$opt = get_option('alo_em_subsc_page');
 		foreach ($pages as $index => $page) {
-			if ($page->ID == get_option('alo_em_subsc_page'))
+			if ($page->ID == $opt)
 				$indexes[] = $index;
 		}
 		foreach ($indexes as $index) {

--- a/functions/alo-easymail-multilingual.php
+++ b/functions/alo-easymail-multilingual.php
@@ -569,17 +569,16 @@ add_filter ( 'alo_easymail_multilang_get_language', 'alo_em_polylang_get_languag
 
 function alo_em_polylang_get_all_languages( $langs, $fallback_by_users  ){
 
-	if ( function_exists('pll_the_languages') )
-	{
-		global $polylang;
-		if (isset($polylang))
-		{
-			$pl_languages = $polylang->get_languages_list();
-			if ( is_array($pl_languages) ) foreach( $pl_languages as $i =>$pl_lang )
-				$langs[] = $pl_lang->slug;
-		}
-	}
-	return $langs;
+    if (function_exists('PLL'))
+    {
+        $pl_languages = PLL()->model->get_languages_list();
+        if (is_array($pl_languages)) {
+            foreach($pl_languages as $i => $pl_lang) {
+                $langs[] = $pl_lang->slug;
+            }
+        }
+    }
+    return $langs;
 }
 add_filter ( 'alo_easymail_multilang_get_all_languages', 'alo_em_polylang_get_all_languages', 10, 2 );
 


### PR DESCRIPTION

Small bug fix on array enumeration: sometimes you had "index jump" and you had this error (notice):

Notice: Trying to get property of non-object in [...]\plugins\alo-easymail\functions\alo-easymail-frontend.php on line 34

So, everything was not properly enumerated, using "foreach" to make an array of the indexes to remove was more secure.